### PR TITLE
Results predictions league screen and podium prediction screen

### DIFF
--- a/frontend/lib/core/models/driver.dart
+++ b/frontend/lib/core/models/driver.dart
@@ -9,6 +9,7 @@ class Driver {
   int seasonPodiums;
   int seasonChampionships;
   int seasonPolePositions;
+  String teamId;
   // List<Season> results;
 
   Driver({
@@ -22,6 +23,7 @@ class Driver {
     required this.seasonPodiums,
     required this.seasonChampionships,
     required this.seasonPolePositions,
+    required this.teamId,
     // required this.results,
   });
 }

--- a/frontend/lib/ui/screens/game/game_predict_screen.dart
+++ b/frontend/lib/ui/screens/game/game_predict_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:frontend/ui/screens/game/predict_podium_screen.dart';
 import 'package:frontend/ui/theme.dart';
 import 'package:intl/intl.dart';
 import 'dart:async';
@@ -50,29 +51,25 @@ class _GamePredictScreenState extends State<GamePredictScreen> {
   @override
   Widget build(BuildContext context) {
     return Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            const Padding(
-              padding: EdgeInsets.all(16.0),
-              child: Text(
-                'GAME',
-                style: TextStyle(
-                    fontSize: 24,
-                    fontWeight: FontWeight.bold,
-                    color: Colors.white),
-              ),
-            ),
-            const SizedBox(height: 16),
-            Padding(
-              padding: const EdgeInsets.all(16.0),
-              child: Center(
-                child: _countdownContainer(),
-              ),
-            ),
-          ],
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Padding(
+          padding: EdgeInsets.all(16.0),
+          child: Text(
+            'GAME',
+            style: TextStyle(
+                fontSize: 24, fontWeight: FontWeight.bold, color: Colors.white),
+          ),
+        ),
+        const SizedBox(height: 16),
+        Padding(
+          padding: const EdgeInsets.all(16.0),
+          child: Center(
+            child: _countdownContainer(),
+          ),
+        ),
+      ],
     );
-    
-  
   }
 
   Widget _countdownContainer() {
@@ -99,14 +96,15 @@ class _GamePredictScreenState extends State<GamePredictScreen> {
             child: const Padding(
               padding: EdgeInsets.all(5),
               child: Text(
-              'FORMULA 1 PIRELLI UNITED STATES GRAND PRIX 2024',
-              style: TextStyle(
-                color: Colors.white,
-                fontWeight: FontWeight.bold,
-                fontSize: 14,
+                'FORMULA 1 PIRELLI UNITED STATES GRAND PRIX 2024',
+                style: TextStyle(
+                  color: Colors.white,
+                  fontWeight: FontWeight.bold,
+                  fontSize: 14,
+                ),
+                textAlign: TextAlign.center,
               ),
-              textAlign: TextAlign.center,
-            ),),
+            ),
           ),
           const SizedBox(height: 25),
           const Text(
@@ -238,7 +236,14 @@ class _GamePredictScreenState extends State<GamePredictScreen> {
                   ),
                 ),
               ),
-              onPressed: () {},
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (context) => PredictPodiumScreen(),
+                  ),
+                );
+              },
               child: const Text(
                 'PLAY',
                 style: TextStyle(

--- a/frontend/lib/ui/screens/game/predict_podium_screen.dart
+++ b/frontend/lib/ui/screens/game/predict_podium_screen.dart
@@ -11,22 +11,9 @@ class PredictPodiumScreen extends StatefulWidget {
 }
 
 class _PredictPodiumScreenState extends State<PredictPodiumScreen> {
-  @override
-  void initState() {
-    super.initState();
-  }
-
-  @override
-  void dispose() {
-    super.dispose();
-  }
-
-  List<Driver?> selectedDrivers = [
-    null,
-    null,
-    null
-  ]; // To store drivers for 1st, 2nd, 3rd positions
+  List<Driver?> selectedDrivers = [null, null, null];
   List<int> disabledDriverIds = [];
+
   List<Driver> drivers = [
     Driver(
       id: 1,
@@ -211,7 +198,7 @@ class _PredictPodiumScreenState extends State<PredictPodiumScreen> {
 
   Widget _predictPodiumContainer() {
     return Container(
-      width: double.infinity, //MediaQuery.of(context).size.width * 0.8,
+      width: double.infinity,
       padding: const EdgeInsets.all(16),
       decoration: BoxDecoration(
         color: primary,
@@ -249,7 +236,6 @@ class _PredictPodiumScreenState extends State<PredictPodiumScreen> {
                         color: Colors.white,
                         fontWeight: FontWeight.bold,
                         fontSize: 14,
-                        
                       ),
                       textAlign: TextAlign.start,
                     ),
@@ -262,12 +248,16 @@ class _PredictPodiumScreenState extends State<PredictPodiumScreen> {
             children: List.generate(3, (index) => _buildPodiumContainer(index)),
           ),
           const SizedBox(height: 30),
-          const Align(alignment: Alignment.centerLeft, child:
-          Text(
-            "Select Drivers",
-            style: TextStyle(
-                color: Colors.white, fontSize: 14, fontWeight: FontWeight.bold),
-          ),),
+          const Align(
+            alignment: Alignment.centerLeft,
+            child: Text(
+              "Select drivers",
+              style: TextStyle(
+                  color: Colors.white,
+                  fontSize: 14,
+                  fontWeight: FontWeight.bold),
+            ),
+          ),
           const SizedBox(height: 15),
           Expanded(
             child: ListView.builder(
@@ -295,31 +285,88 @@ class _PredictPodiumScreenState extends State<PredictPodiumScreen> {
       },
       builder: (context, candidateData, rejectedData) {
         Driver? driver = selectedDrivers[index];
-        return Container(
-          width: MediaQuery.of(context).size.width * 0.25,
-          height: 70,
-          decoration: BoxDecoration(
-            color: Colors.transparent,
-            borderRadius: BorderRadius.circular(10),
-            border: Border.all(color: Colors.white),
-          ),
-          child: driver == null
-              ? Center(
-                  child: Text("${index + 1}st",
-                      style: const TextStyle(color: Colors.white, fontSize: 16)))
-              : Column(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: [
-                    Text(driver.name,
-                        style: const TextStyle(
-                            color: Colors.white, fontWeight: FontWeight.bold)),
-                    Text(driver.teamId,
-                        style: const TextStyle(color: Colors.white70)),
-                  ],
+        return Stack(
+          children: [
+            Container(
+              width: MediaQuery.of(context).size.width * 0.25,
+              height: 70,
+              decoration: BoxDecoration(
+                color: driver == null ? Colors.transparent : Colors.white,
+                borderRadius: BorderRadius.circular(10),
+                border: Border.all(color: Colors.white),
+              ),
+              child: driver == null
+                  ? Center(
+                      child: Text(
+                        "${index + 1}${getOrdinalSuffix(index + 1)}",
+                        style:
+                            const TextStyle(color: Colors.white, fontSize: 16),
+                      ),
+                    )
+                  : Column(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        Text(
+                          "${index + 1}${getOrdinalSuffix(index + 1)}",
+                          style: const TextStyle(
+                              color: Colors.black, fontSize: 14),
+                          textAlign: TextAlign.center,
+                        ),
+                        const SizedBox(
+                          height: 5,
+                        ),
+                        Text(
+                          driver.name,
+                          style: const TextStyle(
+                              color: Colors.black,
+                              fontWeight: FontWeight.bold,
+                              fontSize: 12),
+                          textAlign: TextAlign.center,
+                        ),
+                        /*Text(
+                          driver.teamId,
+                          style: const TextStyle(
+                              color: Colors.white70, fontSize: 12),
+                          textAlign: TextAlign.center,
+                        ),*/
+                      ],
+                    ),
+            ),
+            if (driver != null)
+              Positioned(
+                right: 4,
+                top: 4,
+                child: GestureDetector(
+                  onTap: () {
+                    setState(() {
+                      // Remove the driver from the selected podium and enable them again
+                      selectedDrivers[index] = null;
+                      disabledDriverIds.remove(driver.id);
+                    });
+                  },
+                  child: const Icon(
+                    Icons.close,
+                    color: Colors.red,
+                    size: 18,
+                  ),
                 ),
+              ),
+          ],
         );
       },
     );
+  }
+
+  String getOrdinalSuffix(int number) {
+    if (number == 1) {
+      return "st";
+    } else if (number == 2) {
+      return "nd";
+    } else if (number == 3) {
+      return "rd";
+    } else {
+      return "th";
+    }
   }
 
   // Driver List Tile
@@ -332,7 +379,7 @@ class _PredictPodiumScreenState extends State<PredictPodiumScreen> {
       ),
       onDragCompleted: () {},
       maxSimultaneousDrags: isDisabled ? 0 : 1,
-      child: _buildDriverCard(driver, isDisabled), // Disable if already selected
+      child: _buildDriverCard(driver, isDisabled),
     );
   }
 
@@ -341,15 +388,31 @@ class _PredictPodiumScreenState extends State<PredictPodiumScreen> {
     return Opacity(
       opacity: isDisabled ? 0.5 : 1.0,
       child: Card(
-        color: isDisabled ? Colors.grey[400] : Colors.white,
+        color: Colors.white,
         margin: const EdgeInsets.symmetric(vertical: 4, horizontal: 16),
         child: ListTile(
+          onTap: () {
+            if (!isDisabled) {
+              setState(() {
+                if (selectedDrivers.indexWhere((element) => element == null) !=
+                    -1) {
+                  selectedDrivers[selectedDrivers
+                      .indexWhere((element) => element == null)] = driver;
+                  disabledDriverIds.add(driver.id);
+                }
+              });
+            }
+          },
           leading: const Icon(Icons.flag, color: secondary),
-          title: Text(driver.name,
-              style:
-                  const TextStyle(color: Colors.black, fontWeight: FontWeight.bold)),
-          subtitle:
-              Text(driver.teamId, style: TextStyle(color: Colors.grey[600])),
+          title: Text(
+            driver.name,
+            style: const TextStyle(
+                color: Colors.black, fontWeight: FontWeight.bold),
+          ),
+          subtitle: Text(
+            driver.teamId,
+            style: TextStyle(color: Colors.grey[600]),
+          ),
         ),
       ),
     );

--- a/frontend/lib/ui/screens/game/predict_podium_screen.dart
+++ b/frontend/lib/ui/screens/game/predict_podium_screen.dart
@@ -1,0 +1,357 @@
+import 'package:flutter/material.dart';
+import 'package:frontend/core/models/driver.dart';
+import 'package:frontend/ui/theme.dart';
+
+class PredictPodiumScreen extends StatefulWidget {
+  const PredictPodiumScreen({
+    Key? key,
+  }) : super(key: key);
+
+  _PredictPodiumScreenState createState() => _PredictPodiumScreenState();
+}
+
+class _PredictPodiumScreenState extends State<PredictPodiumScreen> {
+  @override
+  void initState() {
+    super.initState();
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+  }
+
+  List<Driver?> selectedDrivers = [
+    null,
+    null,
+    null
+  ]; // To store drivers for 1st, 2nd, 3rd positions
+  List<int> disabledDriverIds = [];
+  List<Driver> drivers = [
+    Driver(
+      id: 1,
+      name: "Max Verstappen",
+      totalWins: 50,
+      totalPodiums: 85,
+      totalChampionships: 2,
+      totalPolePositions: 30,
+      seasonWins: 10,
+      seasonPodiums: 15,
+      seasonChampionships: 1,
+      seasonPolePositions: 8,
+      teamId: "Red Bull Racing",
+    ),
+    Driver(
+      id: 2,
+      name: "Lewis Hamilton",
+      totalWins: 103,
+      totalPodiums: 182,
+      totalChampionships: 7,
+      totalPolePositions: 103,
+      seasonWins: 5,
+      seasonPodiums: 10,
+      seasonChampionships: 0,
+      seasonPolePositions: 4,
+      teamId: "Mercedes",
+    ),
+    Driver(
+      id: 3,
+      name: "Charles Leclerc",
+      totalWins: 5,
+      totalPodiums: 23,
+      totalChampionships: 0,
+      totalPolePositions: 10,
+      seasonWins: 2,
+      seasonPodiums: 5,
+      seasonChampionships: 0,
+      seasonPolePositions: 3,
+      teamId: "Ferrari",
+    ),
+    Driver(
+      id: 4,
+      name: "Lando Norris",
+      totalWins: 0,
+      totalPodiums: 9,
+      totalChampionships: 0,
+      totalPolePositions: 0,
+      seasonWins: 0,
+      seasonPodiums: 4,
+      seasonChampionships: 0,
+      seasonPolePositions: 0,
+      teamId: "McLaren",
+    ),
+    Driver(
+      id: 5,
+      name: "Sergio Perez",
+      totalWins: 6,
+      totalPodiums: 30,
+      totalChampionships: 0,
+      totalPolePositions: 2,
+      seasonWins: 3,
+      seasonPodiums: 6,
+      seasonChampionships: 0,
+      seasonPolePositions: 1,
+      teamId: "Red Bull Racing",
+    ),
+    Driver(
+      id: 6,
+      name: "Fernando Alonso",
+      totalWins: 32,
+      totalPodiums: 100,
+      totalChampionships: 2,
+      totalPolePositions: 22,
+      seasonWins: 0,
+      seasonPodiums: 6,
+      seasonChampionships: 0,
+      seasonPolePositions: 0,
+      teamId: "Aston Martin",
+    ),
+    Driver(
+      id: 7,
+      name: "Carlos Sainz",
+      totalWins: 2,
+      totalPodiums: 15,
+      totalChampionships: 0,
+      totalPolePositions: 2,
+      seasonWins: 1,
+      seasonPodiums: 3,
+      seasonChampionships: 0,
+      seasonPolePositions: 1,
+      teamId: "Ferrari",
+    ),
+    Driver(
+      id: 8,
+      name: "George Russell",
+      totalWins: 1,
+      totalPodiums: 10,
+      totalChampionships: 0,
+      totalPolePositions: 1,
+      seasonWins: 0,
+      seasonPodiums: 2,
+      seasonChampionships: 0,
+      seasonPolePositions: 0,
+      teamId: "Mercedes",
+    ),
+    Driver(
+      id: 9,
+      name: "Pierre Gasly",
+      totalWins: 1,
+      totalPodiums: 3,
+      totalChampionships: 0,
+      totalPolePositions: 0,
+      seasonWins: 0,
+      seasonPodiums: 1,
+      seasonChampionships: 0,
+      seasonPolePositions: 0,
+      teamId: "Alpine",
+    ),
+    Driver(
+      id: 10,
+      name: "Esteban Ocon",
+      totalWins: 1,
+      totalPodiums: 2,
+      totalChampionships: 0,
+      totalPolePositions: 0,
+      seasonWins: 0,
+      seasonPodiums: 1,
+      seasonChampionships: 0,
+      seasonPolePositions: 0,
+      teamId: "Alpine",
+    ),
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: const BoxDecoration(
+        gradient: LinearGradient(
+          begin: Alignment.topCenter,
+          end: Alignment.bottomCenter,
+          colors: [darkGradient, lightGradient],
+        ),
+      ),
+      child: Scaffold(
+        body: Padding(
+          padding: const EdgeInsets.all(16.0),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                mainAxisAlignment: MainAxisAlignment.start,
+                children: [
+                  IconButton(
+                    icon: const Icon(
+                      Icons.arrow_back,
+                      color: Colors.white,
+                      size: 24.0,
+                    ),
+                    onPressed: () {
+                      Navigator.pop(context);
+                    },
+                  ),
+                  const Text(
+                    'Predictions',
+                    style: TextStyle(
+                        fontSize: 24,
+                        fontWeight: FontWeight.bold,
+                        color: Colors.white),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 16),
+              Expanded(
+                child: _predictPodiumContainer(),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _predictPodiumContainer() {
+    return Container(
+      width: double.infinity, //MediaQuery.of(context).size.width * 0.8,
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: primary,
+        borderRadius: BorderRadius.circular(20),
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Container(
+            padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 16),
+            decoration: BoxDecoration(
+              //color: secondary,
+              border: Border.all(
+                color: secondary,
+                width: 2,
+              ),
+              borderRadius: BorderRadius.circular(8),
+            ),
+            child: const Padding(
+                padding: EdgeInsets.all(5),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      '1 of 3',
+                      style: TextStyle(
+                        color: Colors.white,
+                        fontSize: 12,
+                      ),
+                      textAlign: TextAlign.center,
+                    ),
+                    Text(
+                      'Predict your podium for the United States Grand Prix',
+                      style: TextStyle(
+                        color: Colors.white,
+                        fontWeight: FontWeight.bold,
+                        fontSize: 14,
+                        
+                      ),
+                      textAlign: TextAlign.start,
+                    ),
+                  ],
+                )),
+          ),
+          const SizedBox(height: 25),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+            children: List.generate(3, (index) => _buildPodiumContainer(index)),
+          ),
+          const SizedBox(height: 30),
+          const Align(alignment: Alignment.centerLeft, child:
+          Text(
+            "Select Drivers",
+            style: TextStyle(
+                color: Colors.white, fontSize: 14, fontWeight: FontWeight.bold),
+          ),),
+          const SizedBox(height: 15),
+          Expanded(
+            child: ListView.builder(
+              itemCount: drivers.length,
+              itemBuilder: (context, index) {
+                Driver driver = drivers[index];
+                bool isDisabled = disabledDriverIds.contains(driver.id);
+                return _buildDriverTile(driver, isDisabled);
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  // Podium Container (1st, 2nd, 3rd positions)
+  Widget _buildPodiumContainer(int index) {
+    return DragTarget<Driver>(
+      onAcceptWithDetails: (driver) {
+        setState(() {
+          selectedDrivers[index] = driver.data;
+          disabledDriverIds.add(driver.data.id);
+        });
+      },
+      builder: (context, candidateData, rejectedData) {
+        Driver? driver = selectedDrivers[index];
+        return Container(
+          width: MediaQuery.of(context).size.width * 0.25,
+          height: 70,
+          decoration: BoxDecoration(
+            color: Colors.transparent,
+            borderRadius: BorderRadius.circular(10),
+            border: Border.all(color: Colors.white),
+          ),
+          child: driver == null
+              ? Center(
+                  child: Text("${index + 1}st",
+                      style: const TextStyle(color: Colors.white, fontSize: 16)))
+              : Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    Text(driver.name,
+                        style: const TextStyle(
+                            color: Colors.white, fontWeight: FontWeight.bold)),
+                    Text(driver.teamId,
+                        style: const TextStyle(color: Colors.white70)),
+                  ],
+                ),
+        );
+      },
+    );
+  }
+
+  // Driver List Tile
+  Widget _buildDriverTile(Driver driver, bool isDisabled) {
+    return LongPressDraggable<Driver>(
+      data: driver,
+      feedback: Material(
+        color: Colors.transparent,
+        child: _buildDriverCard(driver, true),
+      ),
+      onDragCompleted: () {},
+      maxSimultaneousDrags: isDisabled ? 0 : 1,
+      child: _buildDriverCard(driver, isDisabled), // Disable if already selected
+    );
+  }
+
+  // Driver Card (UI component for each driver)
+  Widget _buildDriverCard(Driver driver, bool isDisabled) {
+    return Opacity(
+      opacity: isDisabled ? 0.5 : 1.0,
+      child: Card(
+        color: isDisabled ? Colors.grey[400] : Colors.white,
+        margin: const EdgeInsets.symmetric(vertical: 4, horizontal: 16),
+        child: ListTile(
+          leading: const Icon(Icons.flag, color: secondary),
+          title: Text(driver.name,
+              style:
+                  const TextStyle(color: Colors.black, fontWeight: FontWeight.bold)),
+          subtitle:
+              Text(driver.teamId, style: TextStyle(color: Colors.grey[600])),
+        ),
+      ),
+    );
+  }
+}

--- a/frontend/lib/ui/screens/game/ranking_league_screen.dart
+++ b/frontend/lib/ui/screens/game/ranking_league_screen.dart
@@ -1,5 +1,6 @@
 import 'package:carousel_slider/carousel_slider.dart';
 import 'package:flutter/material.dart';
+import 'package:frontend/ui/screens/game/result_prediction_screen.dart';
 import 'package:frontend/ui/theme.dart';
 import 'package:provider/provider.dart';
 
@@ -123,10 +124,14 @@ class _RankingLeagueScreenState extends State<RankingLeagueScreen> {
     return GestureDetector(
       onTap: () {
         // Navigate to another screen when the card is tapped
-        /*Navigator.push(
-                context,
-                MaterialPageRoute(builder: (context) => UserDetailsScreen(user: user)),
-              );*/
+        Navigator.push(
+          context,
+          MaterialPageRoute(
+              builder: (context) => ResultPredictionScreen(
+                    userId: rankingLeague[index]["username"].toString(),
+                    raceId: "",
+                  )),
+        );
       },
       child: Container(
         margin: const EdgeInsets.symmetric(vertical: 4),
@@ -257,8 +262,9 @@ class _RankingLeagueScreenState extends State<RankingLeagueScreen> {
                   }).toList(),
                   options: CarouselOptions(
                     reverse: true,
-                    viewportFraction: 0.15,
-                    height: 30.0,
+                    viewportFraction: 0.20,
+                    height: 35.0,
+                    padEnds: false,
                     enableInfiniteScroll: false,
                     //initialPage: _currentIndex,
                     scrollDirection: Axis.horizontal,

--- a/frontend/lib/ui/screens/game/ranking_league_screen.dart
+++ b/frontend/lib/ui/screens/game/ranking_league_screen.dart
@@ -263,7 +263,7 @@ class _RankingLeagueScreenState extends State<RankingLeagueScreen> {
                   options: CarouselOptions(
                     reverse: true,
                     viewportFraction: 0.20,
-                    height: 35.0,
+                    height: 30.0,
                     padEnds: false,
                     enableInfiniteScroll: false,
                     //initialPage: _currentIndex,

--- a/frontend/lib/ui/screens/game/result_prediction_screen.dart
+++ b/frontend/lib/ui/screens/game/result_prediction_screen.dart
@@ -137,84 +137,91 @@ class _ResultPredictionScreenState extends State<ResultPredictionScreen> {
           const SizedBox(height: 30),
           SingleChildScrollView(
             scrollDirection: Axis.horizontal,
-            child: SizedBox(
-              width: MediaQuery.of(context).size.width + 50,
-              child: ConstrainedBox(
-                constraints:
-                    BoxConstraints(minWidth: MediaQuery.of(context).size.width),
-                child: IntrinsicWidth(
-                  child: Row(
-                    children: [
-                      // Race Results Table
-                      Column(
-                        mainAxisSize: MainAxisSize.min,
-                        crossAxisAlignment: CrossAxisAlignment.start,
+            child: Row(
+              children: [
+                // Race Results Table
+                Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    const Text(
+                      'Race results',
+                      style: TextStyle(
+                          color: Colors.white,
+                          fontSize: 16,
+                          fontWeight: FontWeight.bold),
+                    ),
+                    SizedBox(
+                      width: MediaQuery.of(context).size.width + 50,
+                      child: const Divider(color: Colors.white),
+                    ),
+                    Padding(
+                      padding: const EdgeInsets.symmetric(vertical: 8),
+                      child: Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
                         children: [
-                          const Text(
-                            'Race results',
-                            style: TextStyle(
-                                color: Colors.white,
-                                fontSize: 16,
-                                fontWeight: FontWeight.bold),
-                          ),
-                          const Divider(color: Colors.white),
                           Padding(
-                            padding: const EdgeInsets.symmetric(vertical: 8),
-                            child: Row(
-                              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                              children: [
-                                Padding(
-                                  padding: EdgeInsets.only(left: 95),
-                                  child: Container(
-                                    width: 115,
-                                    child: Text(
-                                      'ACTUAL',
-                                      style: TextStyle(
-                                          color: Colors.white,
-                                          fontSize: 12,
-                                          fontWeight: FontWeight.bold),
-                                    ),
-                                  ),
-                                ),
-                                Container(
-                                  width: 115,
-                                  child: Text(
-                                    widget.userId.toUpperCase(),
-                                    style: const TextStyle(
-                                        color: Colors.redAccent,
-                                        fontSize: 12,
-                                        fontWeight: FontWeight.bold),
-                                  ),
-                                ),
-                                Text(
-                                  'AI',
-                                  style: TextStyle(
-                                      color: Colors.white,
-                                      fontSize: 12,
-                                      fontWeight: FontWeight.bold),
-                                ),
-                              ],
+                            padding: const EdgeInsets.only(left: 95),
+                            child: Container(
+                              width: 115,
+                              child: const Text(
+                                'ACTUAL',
+                                style: TextStyle(
+                                    color: Colors.white,
+                                    fontSize: 12,
+                                    fontWeight: FontWeight.bold),
+                              ),
                             ),
                           ),
-                          const Divider(color: Colors.grey, height: 20),
-                          _buildResultRow(
-                              'Podium',
-                              ['Norris, L', 'Verstappen, M', 'Piastri, O'],
-                              ['Norris, L', 'Verstappen, M', 'Piastri, O'],
-                              ['Norris, L', 'Verstappen, M', 'Piastri, O'],
-                              '+10'),
-                          const Divider(color: Colors.grey, height: 20),
-                          _buildResultRow('Winner', ['Norris, L'],
-                              ['Verstappen, M'], ['Verstappen, M'], '+0'),
-                          const Divider(color: Colors.grey, height: 20),
-                          _buildResultRow('Fastest lap', ['Ricciardo, D'],
-                              ['Verstappen, M'], ['Verstappen, M'], '+10'),
+                          Container(
+                            width: 115,
+                            child: Text(
+                              widget.userId.toUpperCase(),
+                              style: const TextStyle(
+                                  color: Colors.redAccent,
+                                  fontSize: 12,
+                                  fontWeight: FontWeight.bold),
+                            ),
+                          ),
+                          const Text(
+                            'AI',
+                            style: TextStyle(
+                                color: Colors.white,
+                                fontSize: 12,
+                                fontWeight: FontWeight.bold),
+                          ),
                         ],
                       ),
-                    ],
-                  ),
+                    ),
+                    SizedBox(
+                      width: MediaQuery.of(context).size.width + 50,
+                      child: const Divider(color: Colors.grey, height: 20),
+                    ),
+                    _buildResultRow(
+                        'Podium',
+                        ['Norris, L', 'Verstappen, M', 'Piastri, O'],
+                        ['Norris, L', 'Verstappen, M', 'Piastri, O'],
+                        ['Norris, L', 'Verstappen, M', 'Piastri, O'],
+                        '+10'),
+                    SizedBox(
+                      width: MediaQuery.of(context).size.width + 50,
+                      child: const Divider(color: Colors.grey, height: 20),
+                    ),
+                    _buildResultRow('Winner', ['Norris, L'], ['Verstappen, M'],
+                        ['Verstappen, M'], '+0'),
+                    SizedBox(
+                      width: MediaQuery.of(context).size.width + 50,
+                      child: const Divider(color: Colors.grey, height: 20),
+                    ),
+                    _buildResultRow('Fastest lap', ['Ricciardo, D'],
+                        ['Verstappen, M'], ['Verstappen, M'], '+10'),
+                    SizedBox(
+                      width: MediaQuery.of(context).size.width + 50,
+                      child: const Divider(color: Colors.grey, height: 20),
+                    ),
+                  ],
                 ),
-              ),
+              ],
             ),
           ),
         ],

--- a/frontend/lib/ui/screens/game/result_prediction_screen.dart
+++ b/frontend/lib/ui/screens/game/result_prediction_screen.dart
@@ -1,0 +1,324 @@
+import 'package:flutter/material.dart';
+import 'package:carousel_slider/carousel_slider.dart';
+import 'package:frontend/ui/theme.dart';
+
+class ResultPredictionScreen extends StatefulWidget {
+  const ResultPredictionScreen(
+      {Key? key, required this.userId, required this.raceId})
+      : super(key: key);
+
+  final String userId;
+  final String raceId;
+
+  _ResultPredictionScreenState createState() => _ResultPredictionScreenState();
+}
+
+class _ResultPredictionScreenState extends State<ResultPredictionScreen> {
+  // List of flag images for the carousel slider
+  final List<String> flagImages = [
+    'assets/flags/france.png',
+    'assets/flags/germany.png',
+    'assets/flags/spain.png',
+    'assets/flags/united-states.png',
+    'assets/flags/italy.png',
+    'assets/flags/united-kingdom.png',
+    'assets/flags/france.png',
+    'assets/flags/germany.png',
+    'assets/flags/spain.png',
+    'assets/flags/united-states.png',
+    'assets/flags/italy.png',
+    'assets/flags/united-kingdom.png',
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: const BoxDecoration(
+        gradient: LinearGradient(
+          begin: Alignment.topCenter,
+          end: Alignment.bottomCenter,
+          colors: [darkGradient, lightGradient],
+        ),
+      ),
+      child: Scaffold(
+        body: Padding(
+          padding: const EdgeInsets.all(16.0),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                mainAxisAlignment: MainAxisAlignment.start,
+                children: [
+                  IconButton(
+                    icon: const Icon(
+                      Icons.arrow_back,
+                      color: Colors.white,
+                      size: 24.0,
+                    ),
+                    onPressed: () {
+                      Navigator.pop(context);
+                    },
+                  ),
+                  Text(
+                    '${widget.userId} predictions',
+                    style: const TextStyle(
+                        fontSize: 24,
+                        fontWeight: FontWeight.bold,
+                        color: Colors.white),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 16),
+              Expanded(
+                child: _predictionsContainer(),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _predictionsContainer() {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: primary,
+        borderRadius: BorderRadius.circular(20),
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          CarouselSlider(
+            options: CarouselOptions(
+                height: 50,
+                autoPlay: false,
+                enlargeCenterPage: true,
+                reverse: true,
+                viewportFraction: 0.2,
+                enableInfiniteScroll: false),
+            items: flagImages.map((imagePath) {
+              return Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 4.0),
+                child: Image.asset(
+                  imagePath,
+                  fit: BoxFit.cover,
+                  height: 30,
+                ),
+              );
+            }).toList(),
+          ),
+          const SizedBox(height: 30),
+          // Race Title
+          Container(
+            padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 16),
+            decoration: BoxDecoration(
+              //color: secondary,
+              border: Border.all(
+                color: secondary,
+                width: 2,
+              ),
+              borderRadius: BorderRadius.circular(8),
+            ),
+            child: const Padding(
+              padding: EdgeInsets.all(5),
+              child: Text(
+                'UNITED STATES GRAND PRIX',
+                style: TextStyle(
+                  color: Colors.white,
+                  fontWeight: FontWeight.bold,
+                  fontSize: 16,
+                ),
+                textAlign: TextAlign.center,
+              ),
+            ),
+          ),
+          const SizedBox(height: 30),
+          SingleChildScrollView(
+            scrollDirection: Axis.horizontal,
+            child: SizedBox(
+              width: MediaQuery.of(context).size.width + 50,
+              child: ConstrainedBox(
+                constraints:
+                    BoxConstraints(minWidth: MediaQuery.of(context).size.width),
+                child: IntrinsicWidth(
+                  child: Row(
+                    children: [
+                      // Race Results Table
+                      Column(
+                        mainAxisSize: MainAxisSize.min,
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          const Text(
+                            'Race results',
+                            style: TextStyle(
+                                color: Colors.white,
+                                fontSize: 16,
+                                fontWeight: FontWeight.bold),
+                          ),
+                          const Divider(color: Colors.white),
+                          Padding(
+                            padding: const EdgeInsets.symmetric(vertical: 8),
+                            child: Row(
+                              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                              children: [
+                                Padding(
+                                  padding: EdgeInsets.only(left: 95),
+                                  child: Container(
+                                    width: 115,
+                                    child: Text(
+                                      'ACTUAL',
+                                      style: TextStyle(
+                                          color: Colors.white,
+                                          fontSize: 12,
+                                          fontWeight: FontWeight.bold),
+                                    ),
+                                  ),
+                                ),
+                                Container(
+                                  width: 115,
+                                  child: Text(
+                                    widget.userId.toUpperCase(),
+                                    style: const TextStyle(
+                                        color: Colors.redAccent,
+                                        fontSize: 12,
+                                        fontWeight: FontWeight.bold),
+                                  ),
+                                ),
+                                Text(
+                                  'AI',
+                                  style: TextStyle(
+                                      color: Colors.white,
+                                      fontSize: 12,
+                                      fontWeight: FontWeight.bold),
+                                ),
+                              ],
+                            ),
+                          ),
+                          const Divider(color: Colors.grey, height: 20),
+                          _buildResultRow(
+                              'Podium',
+                              ['Norris, L', 'Verstappen, M', 'Piastri, O'],
+                              ['Norris, L', 'Verstappen, M', 'Piastri, O'],
+                              ['Norris, L', 'Verstappen, M', 'Piastri, O'],
+                              '+10'),
+                          const Divider(color: Colors.grey, height: 20),
+                          _buildResultRow('Winner', ['Norris, L'],
+                              ['Verstappen, M'], ['Verstappen, M'], '+0'),
+                          const Divider(color: Colors.grey, height: 20),
+                          _buildResultRow('Fastest lap', ['Ricciardo, D'],
+                              ['Verstappen, M'], ['Verstappen, M'], '+10'),
+                        ],
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildResultRow(String label, List<String> actualResults,
+      List<String> userResults, List<String> AIResults, String points) {
+    return Column(
+      children: [
+        Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // Label
+            Column(
+              children: [
+                Container(
+                  width: 80,
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                  decoration: BoxDecoration(
+                    color: _getLabelColor(label),
+                    borderRadius: BorderRadius.circular(10),
+                  ),
+                  child: Center(
+                    child: Text(
+                      label,
+                      style: const TextStyle(
+                          color: Colors.white,
+                          fontSize: 12,
+                          fontWeight: FontWeight.bold),
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 10),
+                Text(
+                  points,
+                  style: const TextStyle(
+                      color: Colors.white,
+                      fontSize: 12,
+                      fontWeight: FontWeight.bold),
+                ),
+              ],
+            ),
+
+            const SizedBox(width: 15),
+            // Actual results
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: actualResults
+                  .map(
+                    (result) => Container(
+                      width: 100,
+                      child: Text(
+                        result,
+                        style: const TextStyle(color: Colors.white),
+                      ),
+                    ),
+                  )
+                  .toList(),
+            ),
+
+            const SizedBox(width: 15),
+            // User results
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: userResults
+                  .map((result) => Container(
+                      width: 100,
+                      child: Text(
+                        result,
+                        style: const TextStyle(color: Colors.white),
+                      )))
+                  .toList(),
+            ),
+            const SizedBox(width: 15),
+            // AI results
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: AIResults.map((result) => Container(
+                  width: 100,
+                  child: Text(
+                    result,
+                    style: const TextStyle(color: Colors.white),
+                  ))).toList(),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+
+  // Helper method to get the label color
+  Color _getLabelColor(String label) {
+    switch (label) {
+      case 'Podium':
+        return Colors.orange;
+      case 'Winner':
+        return Colors.red;
+      case 'Fastest lap':
+        return Colors.orange;
+      default:
+        return Colors.grey;
+    }
+  }
+}

--- a/frontend/lib/ui/widgets/carousel_game_options.dart
+++ b/frontend/lib/ui/widgets/carousel_game_options.dart
@@ -59,30 +59,32 @@ class _F1CarouselState extends State<F1Carousel> {
             ),
             SizedBox(height: 20),
             Container(
+              alignment: Alignment.center,
+              color: primary,
+              width: double.infinity,
+              padding: const EdgeInsets.only(top: 10.0),
+              child: Align(
                 alignment: Alignment.center,
-                color: primary,
-                width: double.infinity,
-                padding: const EdgeInsets.only(top: 10.0),
-                child: Align(
-                  alignment: Alignment.center,
-                  child: CarouselSlider(
-                    carouselController: carouselController,
-                    options: CarouselOptions(
-                      viewportFraction: 0.4,
-                      height: 45.0,
-                      enableInfiniteScroll: true,
-                      initialPage: _currentIndex,
-                      scrollDirection: Axis.horizontal,
-                      onPageChanged: (index, reason) {
-                        setState(() {
-                          _currentIndex = index;
-                          _pageController.jumpToPage(index);
-                        });
-                      },
-                    ),
-                    items: _buildCarouselItems(),
+                child: CarouselSlider(
+                  carouselController: carouselController,
+                  options: CarouselOptions(
+                    viewportFraction: 0.4,
+                    height: 45.0,
+                    enableInfiniteScroll: true,
+                    initialPage: _currentIndex,
+                    enlargeCenterPage: true,
+                    scrollDirection: Axis.horizontal,
+                    onPageChanged: (index, reason) {
+                      setState(() {
+                        _currentIndex = index;
+                        _pageController.jumpToPage(index);
+                      });
+                    },
                   ),
-                )),
+                  items: _buildCarouselItems(),
+                ),
+              ),
+            ),
             SizedBox(height: 20),
             GestureDetector(
               onPanUpdate: (details) {


### PR DESCRIPTION
Frontend of results predictions league screen and podium prediction screen. Need to test in mobile if in podium prediction screen the drivers' cards can be dragged to the podium container, on web the selection by clicking on the cards works.